### PR TITLE
Change behavior of plugin so that it is bound to a single input field, rather than an empty form

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -4,6 +4,28 @@
         body { font-family: Arial, sans-serif; font-size:13px; }
     </style>
     <link rel="stylesheet" href="jquery.geocodify.css"/>
+    <style>
+        #geocoder {
+            width: 315px;
+            height: 14px;
+            font-size: 14px;
+            line-height: 20px;
+            border: 1px solid #ccc;
+            outline: none;
+            vertical-align: top;
+            padding: 9px 5px;
+            margin: 0;
+            position: relative;
+            z-index: 9002;
+            color: black;
+            font-family: inherit;
+            box-sizing:inherit;
+        }
+
+        #geocoder:focus {
+            border: 1px solid #2262CC;
+        }
+    </style>
     <script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script type="text/javascript" src="http://underscorejs.org/underscore-min.js"></script>
@@ -39,6 +61,11 @@
                 });
             }
         });
+
+        // Prevent demo form from submitting
+        $('form').on('submit', function (e) {
+            e.preventDefault();
+        })
     </script>
 </body>
 </html>

--- a/demo.html
+++ b/demo.html
@@ -12,7 +12,9 @@
 <body>
     <div>
         <h1>Headline here</h1>
-        <div id="geocoder"></div>
+        <form>
+            <input id="geocoder" placeholder="Enter an address..."></input>
+        </form>
         <p>Text goes here and should appear under the dropdown when it shows up.</p>
     </div>
     <script type="text/javascript">
@@ -21,10 +23,9 @@
         var minX = -118.685302734375;
         var maxX = -118.10302734375;
         $("#geocoder").geocodify({
-            onSelect: function (result) { 
+            onSelect: function (result) {
                 console.log(result);
             },
-            initialText: "Enter an address in the Los Angeles city limits",
             regionBias: 'US',
             viewportBias: new google.maps.LatLngBounds(
                  new google.maps.LatLng(33.22030778968541,-118.948974609375),

--- a/jquery.geocodify.css
+++ b/jquery.geocodify.css
@@ -1,25 +1,4 @@
-.geocodifyInput {
-    width: 315px;
-    height: 14px;
-    font-size: 14px;
-    line-height: 20px;
-    border: 1px solid #ccc;
-    outline: none;
-    vertical-align: top;
-    padding: 9px 5px;
-    margin: 0;
-    position: relative;
-    z-index: 9002;
-    color: black;
-    font-family: inherit;
-    box-sizing:inherit;
-}
-
-.geocodifyInput:focus {
-    border: 1px solid #2262CC;
-}
-
-.geocodifyDropdown {
+.geocodify-dropdown {
     position: absolute;
     display:block;
     z-index: 9003;
@@ -32,14 +11,16 @@
     -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    max-height: 250px;
+    overflow: scroll;
 }
 
-.geocodifyDropdown ul {
+.geocodify-dropdown ul {
     margin: 0 !important;
     padding: 0 !important;
 }
 
-.geocodifyDropdown li {
+.geocodify-dropdown li {
     display: block;
     padding: 5px 0 5px 8px;
     cursor: pointer;

--- a/jquery.geocodify.js
+++ b/jquery.geocodify.js
@@ -1,5 +1,6 @@
-
 (function($) {
+    'use strict';
+
     $.fn.geocodify = function(options) {
         var settings = {
             'regionBias': null,
@@ -11,7 +12,6 @@
             'prepSearchString': null,
             'filterResults': null,
             'errorHandler': null,
-            'initialText': null,
             'noResultsText': "No results found. Please refine your search.",
             'acceptableAddressTypes': ['street_address', 'route', 'intersection', 'political', 'country', 'administrative_area_level_1', 'administrative_area_level_2', 'administrative_area_level_3 ', 'colloquial_area', 'locality', 'sublocality', 'neighborhood', 'premise', 'subpremise', 'postal_code', 'natural_feature', 'airport', 'park', 'point_of_interest', 'post_box', 'street_number', 'floor', 'room'],
             'keyCodes': {
@@ -30,8 +30,7 @@
 
         return this.each(function() {
             var $this = $(this),
-                inputId = $this.attr("id") + "-input",
-                input,
+                $input = $this,
                 dropdownId = $this.attr("id") + "-dropdown",
                 dropdown;
 
@@ -39,36 +38,18 @@
                 $.extend(settings, options);
             }
 
-            // Clear out any existing stuff inside the form and set its style
-            $this.empty();
-            document.getElementById($this.attr("id")).setAttribute("autocomplete", "off");
-
-            // Add a text input
-            $('<input>')
-                .attr({
-                type: 'text',
-                id: inputId
-            })
-                .addClass("geocodifyInput")
-                .appendTo($this);
-            document.getElementById(inputId).setAttribute("autocomplete", "off");
-            input = $("#" + inputId);
-
-            // Fill in initialText, if it is specified
-            if (settings.initialText) {
-                if (settings.initialText) {
-                    input.attr('placeholder', settings.initialText);
-                }
-            }
+            // Ensure that autocomplete is turned off on input field
+            $input.attr("autocomplete", "off");
 
             // Add the dropdown box
             $("<div>")
                 .attr({
-                id: dropdownId
-            })
-                .addClass("geocodifyDropdown")
+                    id: dropdownId
+                })
+                .addClass("geocodify-dropdown")
                 .hide()
-                .appendTo($this);
+                .insertAfter($input);
+
             dropdown = $("#" + dropdownId);
 
             // Define what will happen when the form is reset
@@ -84,10 +65,6 @@
             $this.fetch = function(query, force) {
 
                 if (query === $this.previousSearch && force !== true) {
-                    return false;
-                }
-
-                if (query === settings.initialText) {
                     return false;
                 }
 
@@ -166,7 +143,7 @@
                         settings.onSelect(keep[0]);
                         $this.reset();
                         $this.previousSearch = results[0].formatted_address;
-                        input.val(keep[0].formatted_address);
+                        $input.val(keep[0].formatted_address);
                     } else {
                         ul = $("<ul>");
                         $.each(keep, function(i, val) {
@@ -176,7 +153,7 @@
                                 settings.onSelect(val);
                                 $this.reset();
                                 $this.previousSearch = val.formatted_address;
-                                input.val(val.formatted_address);
+                                $input.val(val.formatted_address);
                             })
                                 .hover(
 
@@ -197,7 +174,7 @@
 
             // Bind our geocoding operation to the form
             setInterval(function() {
-                $this.fetch(input.val(), false);
+                $this.fetch($input.val(), false);
             }, 250);
             $this.submit(function() {
                 return false;
@@ -242,7 +219,7 @@
                         if (resultList) {
                             resultList.click();
                         } else {
-                            $this.fetch(input.val(), true);
+                            $this.fetch($input.val(), true);
                         }
                         break;
                     default:
@@ -252,4 +229,4 @@
 
         });
     };
-})(jQuery); 
+})(jQuery);

--- a/jquery.geocodify.js
+++ b/jquery.geocodify.js
@@ -172,12 +172,17 @@
                 };
             };
 
-            // Bind our geocoding operation to the form
-            setInterval(function() {
-                $this.fetch($input.val(), false);
-            }, 250);
-            $this.submit(function() {
-                return false;
+            // Bind our geocoding operation to the input entry
+            $this.on("keyup", function () {
+                $this.fetch($this.val(), false);
+            });
+
+            // Bind dropdown reset to input unfocus
+            $this.on("blur", function () {
+                // Small delay so that script can carry out other actions (like selecting a dropdown entry)
+                window.setTimeout(function () {
+                    $this.reset();
+                }, 200);
             });
 
             // Bind key up and down events


### PR DESCRIPTION
Hey there,

I learned about this at this past SOTM and thought it was perfect for a small project I'm working on (https://github.com/louh/socrata-community-events/tree/gh-pages, demo at http://louhuang.com/socrata-community-events/) - it was way better than entering individual pieces of the address in separate input fields! However, I thought some of the functionality could be improved for my use, so I made some changes to my fork. This is a pull request for these changes in case you're interested in incorporating any of them.

Summary:
- Since I have multiple input fields in a single form, and you can't have nested forms, it's better to have the library functionality bound to a single input field rather than an entire form. Also, the original code as-is would have cleared my own form. So I modified the code to do this.
- This also means the library isn't inserting its own input field, so I removed the input CSS, and deprecated the `initialText` option (since that can be done in HTML with `placeholder`). The only thing it needs to do to modify the original input field is to make sure autocomplete is off.
- On the dropdown CSS I added a maximum height and a scroll, if the content is larger than the maximum height. (Theoretically this could be implemented in other ways, e.g. as an option so users can customize through code.)
- If a user gets out of the input field ('blur's it) then reset the dropdown. Previously it would just stay on the screen.
- If I'm understanding it right, I just added a proposed fix for issue #9. Now instead of polling the page every 250ms for changes, it just fires when the user puts in a new character.
- I also updated the demo page to reflect these changes so you can test it.

To do - if you like these changes and want to incorporate them, I can also help to update the documentation or work out any other issues that might occur.

Thanks for putting together this plugin!

(EDIT: Added one more commit, with notes above.)
